### PR TITLE
Remove educhain identifiers from applications and milestones schemas and GraphQL types

### DIFF
--- a/src/db/migrations/0000_small_skullbuster.sql
+++ b/src/db/migrations/0000_small_skullbuster.sql
@@ -11,7 +11,6 @@ CREATE TABLE "applications" (
 	"content" text,
 	"metadata" jsonb,
 	"price" varchar(256) DEFAULT '0' NOT NULL,
-	"educhain_application_id" integer,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );
@@ -109,7 +108,6 @@ CREATE TABLE "milestones" (
 	"currency" varchar(10) DEFAULT 'ETH',
 	"status" "milestone_status" DEFAULT 'pending' NOT NULL,
 	"links" jsonb,
-	"educhain_milestone_id" integer,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );

--- a/src/db/migrations/meta/0000_snapshot.json
+++ b/src/db/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "27b8ea4c-2961-46e0-94f7-09d88c8cae7f",
+  "id": "164dcade-f2e6-4995-88d7-ee92e53218a2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -59,12 +59,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'0'"
-        },
-        "educhain_application_id": {
-          "name": "educhain_application_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -834,12 +828,6 @@
         "links": {
           "name": "links",
           "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "educhain_milestone_id": {
-          "name": "educhain_milestone_id",
-          "type": "integer",
           "primaryKey": false,
           "notNull": false
         },

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1744522010116,
-      "tag": "0000_useful_phil_sheldon",
+      "when": 1745211579735,
+      "tag": "0000_small_skullbuster",
       "breakpoints": true
     }
   ]

--- a/src/db/schemas/applications.ts
+++ b/src/db/schemas/applications.ts
@@ -1,14 +1,5 @@
 import { relations } from 'drizzle-orm';
-import {
-  integer,
-  jsonb,
-  pgEnum,
-  pgTable,
-  text,
-  timestamp,
-  uuid,
-  varchar,
-} from 'drizzle-orm/pg-core';
+import { jsonb, pgEnum, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { linksTable } from './links';
 import { milestonesTable } from './milestones';
 import { programsTable } from './programs';
@@ -40,7 +31,6 @@ export const applicationsTable = pgTable('applications', {
   content: text('content'),
   metadata: jsonb('metadata'),
   price: varchar('price', { length: 256 }).default('0').notNull(),
-  educhainApplicationId: integer('educhain_application_id'),
 
   // Timestamps
   createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),

--- a/src/db/schemas/milestones.ts
+++ b/src/db/schemas/milestones.ts
@@ -1,6 +1,5 @@
 import { relations } from 'drizzle-orm';
 import {
-  integer,
   jsonb,
   pgEnum,
   pgTable,
@@ -36,7 +35,6 @@ export const milestonesTable = pgTable('milestones', {
   currency: varchar('currency', { length: 10 }).default('ETH'),
   status: milestoneStatusEnum('status').default('pending').notNull(),
   links: jsonb('links').$type<{ url: string; title: string }[]>(),
-  educhainMilestoneId: integer('educhain_milestone_id'),
 
   // Timestamps
   createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),

--- a/src/graphql/resolvers/milestones.ts
+++ b/src/graphql/resolvers/milestones.ts
@@ -95,7 +95,7 @@ export function createMilestonesResolver(
       const { links, ...inputData } = milestone;
       const [newMilestone] = await t
         .insert(milestonesTable)
-        .values({ ...inputData, educhainMilestoneId: milestone.educhainMilestoneId })
+        .values({ ...inputData })
         .returning();
       // handle links
       if (links) {
@@ -154,7 +154,6 @@ export function createMilestonesResolver(
       .update(applicationsTable)
       .set({
         price: milestonesTotalPrice.toString(),
-        educhainApplicationId: args.input[0].educhainApplicationId,
       })
       .where(eq(applicationsTable.id, args.input[0].applicationId));
 
@@ -292,10 +291,6 @@ export function checkMilestoneResolver(
       .set({ status: args.input.status })
       .where(eq(milestonesTable.id, args.input.id))
       .returning();
-
-    if (!milestone.educhainMilestoneId) {
-      throw new Error('Milestone not found on blockchain');
-    }
 
     return milestone;
   });

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,7 +1,6 @@
 type Application {
   applicant: User
   content: String
-  educhainApplicationId: Int
   id: ID
   links: [Link!]
   metadata: JSON
@@ -42,8 +41,6 @@ input CreateMilestoneInput {
   applicationId: String!
   currency: String! = "ETH"
   description: String
-  educhainApplicationId: Int!
-  educhainMilestoneId: Int!
   links: [LinkInput!]
   price: String!
   title: String!
@@ -94,7 +91,6 @@ input LinkInput {
 type Milestone {
   currency: String
   description: String
-  educhainMilestoneId: Int
   id: ID
   links: [Link!]
   price: String

--- a/src/graphql/types/applications.ts
+++ b/src/graphql/types/applications.ts
@@ -36,7 +36,6 @@ export const ApplicationType = builder.objectRef<DBApplication>('Application').i
     name: t.exposeString('name', { nullable: true }),
     content: t.exposeString('content', { nullable: true }),
     price: t.exposeString('price'),
-    educhainApplicationId: t.exposeInt('educhainApplicationId', { nullable: true }),
     metadata: t.field({
       type: 'JSON',
       nullable: true,

--- a/src/graphql/types/milestones.ts
+++ b/src/graphql/types/milestones.ts
@@ -27,7 +27,6 @@ export const MilestoneType = builder.objectRef<DBMilestone>('Milestone').impleme
     description: t.exposeString('description', { nullable: true }),
     price: t.exposeString('price'),
     currency: t.exposeString('currency'),
-    educhainMilestoneId: t.exposeInt('educhainMilestoneId', { nullable: true }),
     status: t.field({
       type: MilestoneStatusEnum,
       resolve: (milestone) => milestone.status,
@@ -55,8 +54,6 @@ export const PaginatedMilestonesType = builder
 export const CreateMilestoneInput = builder.inputType('CreateMilestoneInput', {
   fields: (t) => ({
     applicationId: t.string({ required: true }),
-    educhainApplicationId: t.int({ required: true }),
-    educhainMilestoneId: t.int({ required: true }),
     title: t.string({ required: true }),
     description: t.string(),
     price: t.string({


### PR DESCRIPTION
- Deleted `educhainApplicationId` and `educhainMilestoneId` fields from the applications and milestones database schemas.
- Updated GraphQL types and input definitions to remove references to `educhainApplicationId` and `educhainMilestoneId`.
- Adjusted resolver logic to eliminate the use of these identifiers, ensuring a cleaner and more focused implementation.
